### PR TITLE
Add a Makefile with convenience commands

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,4 @@ README.html
 htmlcov
 .idea
 .DS_Store
+venv

--- a/Makefile
+++ b/Makefile
@@ -26,10 +26,8 @@ test-install: venv
 		--download-cache /tmp/pipcache
 
 test:
-	. venv/bin/activate; cd venv/build/httpbin && \
-		python manage.py runserver -p $(PORT) &
-	sleep 5
+	. venv/bin/activate; python venv/build/httpbin/manage.py runserver -p $(PORT) &
 	- . venv/bin/activate; HTTPBIN_URL=http://127.0.0.1:$(PORT) python setup.py test
 	- . venv/bin/activate; HTTPBIN_URL=http://127.0.0.1:$(PORT) tox
 	@# We need to kill the django process as well as its subprocesses.
-	kill -9 `pgrep -f "manage.py runserver -p $(PORT)"`
+	kill -9 `pgrep -f "venv/build/httpbin/manage.py runserver -p $(PORT)"`

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,35 @@
+.PHONY: install clean venv test-install test
+
+PORT=8008
+
+clean:
+	rm -rf venv
+
+venv:
+	virtualenv venv
+
+install: venv
+	. venv/bin/activate; pip install . --upgrade --download-cache /tmp/pipcache
+	@echo "\033[95m\n\nInstalled! Add ${PWD}/venv/bin to your \$$PATH to use the http command.\n\033[0m"
+
+test-install: venv
+	# Stupidly httpbin stopped including a setup.py file two months ago making
+	# the normal pip install process impossible with HEAD. Until then install
+	# the last git commit that works. For more see 
+	# https://github.com/kennethreitz/httpbin/pull/111#issuecomment-24450148
+	if [ ! -d venv/build/httpbin ]; then \
+		git clone https://github.com/kennethreitz/httpbin.git venv/build/httpbin; \
+		. venv/bin/activate; pip install -r venv/build/httpbin/requirements.txt \
+			--download-cache /tmp/pipcache; \
+	fi
+	. venv/bin/activate; pip install -r requirements-dev.txt \
+		--download-cache /tmp/pipcache
+
+test:
+	. venv/bin/activate; cd venv/build/httpbin && \
+		python manage.py runserver -p $(PORT) &
+	sleep 5
+	- . venv/bin/activate; HTTPBIN_URL=http://127.0.0.1:$(PORT) python setup.py test
+	- . venv/bin/activate; HTTPBIN_URL=http://127.0.0.1:$(PORT) tox
+	@# We need to kill the django process as well as its subprocesses.
+	kill -9 `pgrep -f "manage.py runserver -p $(PORT)"`

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,2 +1,3 @@
+# Run "make test-install" to install test dependencies
 tox
 docutils

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,3 +1,2 @@
 tox
-git+git://github.com/kennethreitz/httpbin.git@7c96875e87a448f08fb1981e85eb79e77d592d98
 docutils


### PR DESCRIPTION
Some users can't install `httpie` into the global namespace, because of conflicts with dependencies like requests in other projects. This means those users have to do something like this:

```bash
mkvirtualenv httpie
pip install httpie
```

and then use a wrapper alias like this:

```bash
alias http=`~/.envs/httpie/bin/http`
```

Instead this adds a Makefile so you can clone the library and run `make install` to install it.

There are also helper commands for the tests:

```
make test-install
make test
```

I couldn't get httpbin to install by running "pip install -r requirements-dev.txt", I ran into the following error:

```bash
Scanning installed packages

Setuptools installation detected at /Users/kevin/code/httpie/venv/lib/python2.7/site-packages

Non-egg installation

Removing elements out of the way...

Renaming /Users/kevin/code/httpie/venv/lib/python2.7/site-packages/setuptools-0.9.7-py2.7.egg-info into /Users/kevin/code/httpie/venv/lib/python2.7/site-packages/setuptools-0.9.7-py2.7.egg-info.OLD.1379182538.52

Renaming /Users/kevin/code/httpie/venv/lib/python2.7/site-packages/setuptools into /Users/kevin/code/httpie/venv/lib/python2.7/site-packages/setuptools.OLD.1379182538.52

Renaming /Users/kevin/code/httpie/venv/lib/python2.7/site-packages/pkg_resources.py into /Users/kevin/code/httpie/venv/lib/python2.7/site-packages/pkg_resources.py.OLD.1379182538.52

Could not find the /Users/kevin/code/httpie/venv/lib/python2.7/site-packages/site.py element of the Setuptools distribution

Patched done.

Relaunching...

Traceback (most recent call last):

  File "<string>", line 1, in <module>

NameError: name 'install' is not defined
```

There's an issue with httpbin here that seems to get the same error: https://github.com/kennethreitz/httpbin/issues/106, but the corresponding PR was just closed with no comment so I'm not sure what the plan is. Anyway I got around it by cloning the library locally and running `pip install -r requirements.txt`.

I also had problems running the test suite locally. It seems that the test runner is looking for `HTTP/1.1 200` where httpbin responds with `HTTP/1.0 200`.