### PR TITLE
Read password from environment variable

### DIFF
--- a/httpie/input.py
+++ b/httpie/input.py
@@ -201,13 +201,18 @@ class Parser(ArgumentParser):
         """
         url = urlsplit(self.args.url)
 
+        password_from_env = os.getenv("HTTPIE_PASSWORD")
+
         if self.args.auth:
             if not self.args.auth.has_password():
+                if password_from_env:
+                    self.args.auth.value = password_from_env
                 # Stdin already read (if not a tty) so it's save to prompt.
-                if self.args.ignore_stdin:
+                elif self.args.ignore_stdin:
                     self.error('Unable to prompt for passwords because'
                                ' --ignore-stdin is set.')
-                self.args.auth.prompt_password(url.netloc)
+                else:
+                    self.args.auth.prompt_password(url.netloc)
 
         elif url.username is not None:
             # Handle http://username:password@hostname/

--- a/tests/test_auth.py
+++ b/tests/test_auth.py
@@ -13,6 +13,15 @@ class TestAuth:
         assert HTTP_OK in r
         assert r.json == {'authenticated': True, 'user': 'user'}
 
+    def test_basic_auth_from_environment(self):
+        import os
+        os.environ["HTTPIE_PASSWORD"] = "password"
+        r = http('--auth=user',
+                 'GET', httpbin('/basic-auth/user/password'))
+        assert HTTP_OK in r
+        assert r.json == {'authenticated': True, 'user': 'user'}
+        del os.environ["HTTPIE_PASSWORD"]
+
     @pytest.mark.skipif(
         requests.__version__ == '0.13.6',
         reason='Redirects with prefetch=False are broken in Requests 0.13.6')


### PR DESCRIPTION
If the password is not provided via the command line, try to read it from the HTTPIE_PASSWORD environment variable.

This is meant as a simple way to avoid leaking the password via the process title in scripted runs.
