### PR TITLE
Add extra dependencies to support SNI

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -62,6 +62,7 @@ extras_require = {
     ' or python_version == "3.0"'
     ' or python_version == "3.1" ': ['argparse>=1.2.1'],
     ':sys_platform == "win32"': ['colorama>=0.2.4'],
+    'security': ['pyOpenSSL', 'ndg-httpsclient', 'pyasn1'],
 }
 
 


### PR DESCRIPTION
Then we could install httpie in [pipsi](https://github.com/mitsuhiko/pipsi) with SNI support:

```
$ pipsi install httpie[security]
```

It is the same as [requests](https://github.com/kennethreitz/requests/blob/359659cf4b9dbeeef1ed832501dc1f99b0f0beac/setup.py#L65-L67) done.

Related Topics:
- https://github.com/kennethreitz/requests/issues/749
- https://github.com/jakubroztocil/httpie/issues/262
- https://github.com/jakubroztocil/httpie/issues/154
