### PR TITLE
Add support for unix domain sockets

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -298,6 +298,16 @@ command:
 
     GET /?search=HTTPie&tbm=isch HTTP/1.1
 
+To issue HTTP requests to a UNIX domain socket (added in `0.9.0-dev`_):
+
+* Use new ``http+unix://`` scheme in URL.
+* Use url-encoded socket path as the hostname part of the URL.
+  e.g.: for a socket at ``/tmp/profilesvc.sock``, you could do:
+
+.. code-block:: bash
+
+    $ http http+unix://%2Ftmp%2Fprofilesvc.sock/status/pid
+
 
 =============
 Request Items
@@ -1329,6 +1339,8 @@ Changelog
     * Fixed handling of empty passwords in URL credentials.
     * Fixed multiple file uploads with the same form field name.
     * Fixed ``--output=/dev/null`` on Linux.
+    * Improved terminal color depth detection via ``curses``.
+    * Add support for unix domain sockets with ``http+unix://`` scheme.
     * Miscellaneous bugfixes.
 * `0.8.0`_ (2014-01-25)
     * Added ``field=@file.txt`` and ``field:=@file.json`` for embedding

--- a/httpie/client.py
+++ b/httpie/client.py
@@ -3,6 +3,7 @@ import sys
 from pprint import pformat
 
 import requests
+import requests_unixsocket
 
 from httpie import sessions
 from httpie import __version__
@@ -22,7 +23,7 @@ def get_response(args, config_dir):
         requests_kwargs = get_requests_kwargs(args)
         if args.debug:
             dump_request(requests_kwargs)
-        response = requests.request(**requests_kwargs)
+        response = get_session().request(**requests_kwargs)
     else:
         response = sessions.get_response(
             args=args,
@@ -32,6 +33,10 @@ def get_response(args, config_dir):
         )
 
     return response
+
+
+def get_session():
+    return requests_unixsocket.Session()
 
 
 def dump_request(kwargs):

--- a/httpie/input.py
+++ b/httpie/input.py
@@ -25,6 +25,7 @@ HTTP_POST = 'POST'
 HTTP_GET = 'GET'
 HTTP = 'http://'
 HTTPS = 'https://'
+HTTP_UNIX = 'http+unix://'
 
 
 # Various separators used in args
@@ -132,7 +133,7 @@ class Parser(ArgumentParser):
         self._parse_items()
         if not self.args.ignore_stdin and not env.stdin_isatty:
             self._body_from_file(self.env.stdin)
-        if not (self.args.url.startswith((HTTP, HTTPS))):
+        if not (self.args.url.startswith((HTTP, HTTPS, HTTP_UNIX))):
             scheme = HTTP
 
             # See if we're using curl style shorthand for localhost (:3000/foo)

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -4,3 +4,4 @@ pytest-cov
 pytest-httpbin
 docutils
 wheel
+waitress

--- a/setup.py
+++ b/setup.py
@@ -36,6 +36,7 @@ tests_require = [
 
 install_requires = [
     'requests>=2.3.0',
+    'requests-unixsocket>=0.1.2',
     'Pygments>=1.5'
 ]
 

--- a/tests/test_unix_socket.py
+++ b/tests/test_unix_socket.py
@@ -1,0 +1,48 @@
+# coding=utf-8
+"""Tests for unix domain socket support
+
+"""
+
+import multiprocessing
+import os
+import time
+import uuid
+
+import pytest
+from requests import ConnectionError
+from requests_unixsocket.testutils import UnixSocketServerThread
+
+from utils import http, HTTP_OK
+
+
+class TestUnixSocket:
+
+    def test_unix_domain_adapter_ok(self):
+        from requests.compat import quote_plus
+
+        with UnixSocketServerThread() as usock_thread:
+            print('usock_thread.usock = %r' % usock_thread.usock)
+            urlencoded_socket_name = quote_plus(usock_thread.usock)
+            print('urlencoded_socket_name = %r' % urlencoded_socket_name)
+            url = 'http+unix://%s/path/to/page' % urlencoded_socket_name
+            print('url = %r' % url)
+
+            for i in range(1, 5):
+                try:
+                    r = http('GET', url)
+                    break
+                except ConnectionError:
+                    time.sleep(1)
+                r = http('GET', url)
+
+            assert HTTP_OK in r
+            print('r = %r' % r)
+            assert 'Server: waitress' in r
+            assert 'X-Transport: unix domain socket' in r
+            assert 'X-Requested-Path: /path/to/page' in r
+            assert 'X-Socket-Path: %s' % usock_thread.usock in r
+            assert 'Hello world' in r
+
+    def test_unix_domain_adapter_connection_error(self):
+        with pytest.raises(ConnectionError):
+            http('GET', 'http+unix://socket_does_not_exist/path/to/page')

--- a/tox.ini
+++ b/tox.ini
@@ -13,6 +13,7 @@ envlist = py26, py27, py34, pypy
 deps =
     pytest
     pytest-httpbin
+    waitress
 
 commands =
     py.test --verbose --doctest-modules --basetemp={envtmpdir} {posargs:./tests ./httpie}


### PR DESCRIPTION
To issue HTTP requests to a UNIX domain socket:

* Use new `"http+unix://"` scheme in URL.
* Use urlencoded socket path as the hostname part of the URL.
  e.g.: for a socket at `/tmp/profilesvc.sock`, you could do:

      http http+unix://%2Ftmp%2Fprofilesvc.sock/status/pid

This uses https://pypi.python.org/pypi/requests-unixsocket

Fixes: GH-209 (https://github.com/jakubroztocil/httpie/issues/209)

#### Screenshot

![screen shot 2014-11-24 at 6 35 24 pm](https://cloud.githubusercontent.com/assets/305268/5177115/dba014c6-7408-11e4-8376-78a57a39909b.png)

Cc: @shin-, @jakubroztocil, @monsanto, @np, @nuxlli, @matrixise, @remmelt