### PR TITLE
Addresses Issue #243

### DIFF
--- a/httpie/cli.py
+++ b/httpie/cli.py
@@ -16,7 +16,7 @@ from httpie.output.formatters.colors import AVAILABLE_STYLES, DEFAULT_STYLE
 from httpie.input import (Parser, AuthCredentialsArgType, KeyValueArgType,
                           SEP_PROXY, SEP_CREDENTIALS, SEP_GROUP_ALL_ITEMS,
                           OUT_REQ_HEAD, OUT_REQ_BODY, OUT_RESP_HEAD,
-                          OUT_RESP_BODY, OUTPUT_OPTIONS,
+                          OUT_RESP_BODY, OUT_RESP_TIME, OUTPUT_OPTIONS,
                           OUTPUT_OPTIONS_DEFAULT, PRETTY_MAP,
                           PRETTY_STDOUT_TTY_ONLY, SessionNameValidator,
                           readable_file_arg)
@@ -234,6 +234,7 @@ output_options.add_argument(
         '{req_body}' request body
         '{res_head}' response headers
         '{res_body}' response body
+        '{res_time}' response time
 
     The default behaviour is '{default}' (i.e., the response headers and body
     is printed), if standard output is not redirected. If the output is piped
@@ -246,6 +247,7 @@ output_options.add_argument(
         req_body=OUT_REQ_BODY,
         res_head=OUT_RESP_HEAD,
         res_body=OUT_RESP_BODY,
+        res_time=OUT_RESP_TIME,
         default=OUTPUT_OPTIONS_DEFAULT,
     )
 )

--- a/httpie/client.py
+++ b/httpie/client.py
@@ -31,6 +31,9 @@ def get_response(args, config_dir):
             read_only=bool(args.session_read_only),
         )
 
+    with open('/home/daniel/mydebug.log', mode='w', encoding='utf-8') as a_file:
+        a_file.write("Response elapsed: {}".format(response.elapsed))
+
     return response
 
 

--- a/httpie/client.py
+++ b/httpie/client.py
@@ -31,9 +31,6 @@ def get_response(args, config_dir):
             read_only=bool(args.session_read_only),
         )
 
-    with open('/home/daniel/mydebug.log', mode='w', encoding='utf-8') as a_file:
-        a_file.write("Response elapsed: {}".format(response.elapsed))
-
     return response
 
 

--- a/httpie/input.py
+++ b/httpie/input.py
@@ -76,12 +76,14 @@ OUT_REQ_HEAD = 'H'
 OUT_REQ_BODY = 'B'
 OUT_RESP_HEAD = 'h'
 OUT_RESP_BODY = 'b'
+OUT_RESP_TIME = 't'
 
 OUTPUT_OPTIONS = frozenset([
     OUT_REQ_HEAD,
     OUT_REQ_BODY,
     OUT_RESP_HEAD,
-    OUT_RESP_BODY
+    OUT_RESP_BODY,
+    OUT_RESP_TIME
 ])
 
 # Pretty


### PR DESCRIPTION
This is my attempt at addressing issue #243. It adds a 't' option to the -p (print) command so that the elapsed time can be displayed at the end of the output.

It works as-is with one problem: the body gets printed by default (even with JUST "-p t"). I wasn't able to track down why that was happening.
