### PR TITLE
use OrderedDict for json formating to preserve key ordering

### DIFF
--- a/httpie/output/formatters/json.py
+++ b/httpie/output/formatters/json.py
@@ -1,5 +1,6 @@
 from __future__ import absolute_import
 import json
+import collections
 
 from httpie.plugins import FormatterPlugin
 
@@ -12,7 +13,7 @@ class JSONFormatter(FormatterPlugin):
     def format_body(self, body, mime):
         if 'json' in mime:
             try:
-                obj = json.loads(body)
+                obj = json.loads(body, object_pairs_hook=collections.OrderedDict)
             except ValueError:
                 # Invalid JSON, ignore.
                 pass
@@ -20,7 +21,7 @@ class JSONFormatter(FormatterPlugin):
                 # Indent, sort keys by name, and avoid
                 # unicode escapes to improve readability.
                 body = json.dumps(obj,
-                                  sort_keys=True,
+                                  sort_keys=False,
                                   ensure_ascii=False,
                                   indent=DEFAULT_INDENT)
         return body

--- a/httpie/output/formatters/json.py
+++ b/httpie/output/formatters/json.py
@@ -1,6 +1,8 @@
 from __future__ import absolute_import
 import json
-import collections
+import sys
+if sys.version_info >= (2, 7):
+    from collections import OrderedDict
 
 from httpie.plugins import FormatterPlugin
 
@@ -13,15 +15,22 @@ class JSONFormatter(FormatterPlugin):
     def format_body(self, body, mime):
         if 'json' in mime:
             try:
-                obj = json.loads(body, object_pairs_hook=collections.OrderedDict)
+                if sys.version_info >= (2, 7):
+                    obj = json.loads(body, object_pairs_hook=OrderedDict)
+                else:
+                    obj = json.loads(body)
             except ValueError:
                 # Invalid JSON, ignore.
                 pass
             else:
-                # Indent, sort keys by name, and avoid
-                # unicode escapes to improve readability.
+                # Indent, sort keys by name depending on version
+                # and avoid unicode escapes to improve readability.
+                if sys.version_info >= (2, 7):
+                    sort_keys=False
+                else:
+                    sort_keys=True
                 body = json.dumps(obj,
-                                  sort_keys=False,
+                                  sort_keys=sort_keys,
                                   ensure_ascii=False,
                                   indent=DEFAULT_INDENT)
         return body

--- a/httpie/output/formatters/json.py
+++ b/httpie/output/formatters/json.py
@@ -23,7 +23,7 @@ class JSONFormatter(FormatterPlugin):
                 # Invalid JSON, ignore.
                 pass
             else:
-                # Indent, sort keys by name depending on version
+                # Indent, sort keys by name  depending on version
                 # and avoid unicode escapes to improve readability.
                 if sys.version_info >= (2, 7):
                     sort_keys=False


### PR DESCRIPTION
passing collections.OrderedDict to "object_pairs_hook" option of json.load function and making "sort_keys" option in json.dumps function False