### PR TITLE
Loosen check for "http" scheme in URL

### DIFF
--- a/httpie/input.py
+++ b/httpie/input.py
@@ -23,8 +23,6 @@ from httpie.utils import load_json_preserve_order
 
 HTTP_POST = 'POST'
 HTTP_GET = 'GET'
-HTTP = 'http://'
-HTTPS = 'https://'
 
 
 # Various separators used in args
@@ -132,7 +130,7 @@ class Parser(ArgumentParser):
         self._parse_items()
         if not self.args.ignore_stdin and not env.stdin_isatty:
             self._body_from_file(self.env.stdin)
-        if not (self.args.url.startswith((HTTP, HTTPS))):
+        if not re.match(r'^http.*://', self.args.url):
             scheme = HTTP
 
             # See if we're using curl style shorthand for localhost (:3000/foo)


### PR DESCRIPTION
```diff
-        if not (self.args.url.startswith((HTTP, HTTPS))):
+        if not re.match(r'^http.*://', self.args.url):
```

This allows us to accommodate new connection schemes such as the "http+unix" scheme being discussed in https://github.com/jakubroztocil/httpie/pull/276