### PR TITLE
.travis.yml: Only do coveralls on one Python version

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,6 +2,9 @@
 os:
   - linux
   - osx
+env:
+  global:
+    - NEWEST_PYTHON=3.4
 language: python
 python:
   - 2.6
@@ -13,5 +16,4 @@ python:
 script:
   - make
 after_success:
-  - pip install python-coveralls
-  - coveralls
+  - if [[ $TRAVIS_PYTHON_VERSION == $NEWEST_PYTHON ]]; then pip install python-coveralls && coveralls; fi


### PR DESCRIPTION
Testing theory that it has to do with different python version subjobs completing in different orders and the last one wins.