### PR TITLE
Bash auto completion

### DIFF
--- a/httpie-completion.bash
+++ b/httpie-completion.bash
@@ -1,0 +1,22 @@
+#!/bin/env bash
+
+_http_complete() {
+	local cur_word=${COMP_WORDS[COMP_CWORD]}
+	local prev_word=${COMP_WORDS[COMP_CWORD - 1]}
+
+	if [[ "$cur_word" == -*  ]]; then
+		_http_complete_options "$cur_word"
+	fi
+}
+
+complete -o default -F _http_complete http
+
+_http_complete_options() {
+	local cur_word=$1
+	local options="-j --json -f --form --pretty -s --style -p --print 
+	-v --verbose -h --headers -b --body -S --stream -o --output -d --download
+	-c --continue --session --session-read-only -a --auth --auth-type --proxy
+	--follow --verify --cert --cert-key --timeout --check-status --ignore-stdin
+	--help --version --traceback --debug"
+	COMPREPLY=( $( compgen -W "$options" -- "$cur_word" ) )
+}


### PR DESCRIPTION
See #326 

Adds bash completion to http command line interface.

Installing the script:
You can copy it to /etc/bash_completion.d/ (or something else on your
machine) and source it using following command

	$ source /etc/profile

Now whenever you encounter a "-*" on your CLI, it presents you with the
options specified.

Couple of things that are still under work:
1) Adding this bash script to setup, so that user won't need manual
installation
2) Adding more options for HTTP (GET, PUT and so on) and other
options