### PR TITLE
Only serialize json if data is a dict instance

### DIFF
--- a/httpie/client.py
+++ b/httpie/client.py
@@ -92,7 +92,7 @@ def get_requests_kwargs(args, base_headers=None):
     # Serialize JSON data, if needed.
     data = args.data
     auto_json = data and not args.form
-    if args.json or auto_json and isinstance(data, dict):
+    if (args.json or auto_json) and isinstance(data, dict):
         if data:
             data = json.dumps(data)
         else:


### PR DESCRIPTION
Only serialize json data if it's  a `dict`.

Fixes #336