### PR TITLE
Add XDG_CONFIG_HOME support.

### DIFF
--- a/httpie/config.py
+++ b/httpie/config.py
@@ -6,6 +6,9 @@ from httpie import __version__
 from httpie.compat import is_windows
 
 def get_default_config_dir():
+    """Returns the path to the httpie config directory.
+
+    Supports Windows and XDG_CONFIG_HOME."""
     env_config_dir = os.environ.get("HTTPIE_CONFIG_DIR")
     if env_config_dir:
         return env_config_dir

--- a/httpie/config.py
+++ b/httpie/config.py
@@ -5,13 +5,18 @@ import errno
 from httpie import __version__
 from httpie.compat import is_windows
 
+def get_default_config_dir():
+    env_config_dir = os.environ.get("HTTPIE_CONFIG_DIR")
+    if env_config_dir:
+        return env_config_dir
+    elif is_windows:
+        return os.path.expandvars(r'%APPDATA%\httpie')
+    else:
+        config_dir = os.environ.get("XDG_CONFIG_HOME",
+                                    os.path.expanduser("~/.config/"))
+        return os.path.join(config_dir, "httpie")
 
-DEFAULT_CONFIG_DIR = str(os.environ.get(
-    'HTTPIE_CONFIG_DIR',
-    os.path.expanduser('~/.httpie') if not is_windows else
-    os.path.expandvars(r'%APPDATA%\\httpie')
-))
-
+DEFAULT_CONFIG_DIR = get_default_config_dir()
 
 class BaseConfigDict(dict):
 

--- a/httpie/config.py
+++ b/httpie/config.py
@@ -5,6 +5,7 @@ import errno
 from httpie import __version__
 from httpie.compat import is_windows
 
+
 def get_default_config_dir():
     """Returns the path to the httpie config directory.
 
@@ -15,11 +16,13 @@ def get_default_config_dir():
     elif is_windows:
         return os.path.expandvars(r'%APPDATA%\httpie')
     else:
-        config_dir = os.environ.get("XDG_CONFIG_HOME",
-                                    os.path.expanduser("~/.config/"))
+        config_dir = os.environ.get("XDG_CONFIG_HOME")
+        if not config_dir or not config_dir.startswith("/"):
+            config_dir = os.path.expanduser("~/.config/")
         return os.path.join(config_dir, "httpie")
 
 DEFAULT_CONFIG_DIR = get_default_config_dir()
+
 
 class BaseConfigDict(dict):
 


### PR DESCRIPTION
On Linux and Mac, the default config directory is now "~/.config/httpie" instead
of "~/.httpie". Fixes https://github.com/jkbrzt/httpie/issues/145
