### PR TITLE
Adds a 'httpie' alias to fix #505

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -83,6 +83,7 @@ setup(
     entry_points={
         'console_scripts': [
             'http = httpie.__main__:main',
+            'httpie = httpie.__main__:main',
         ],
     },
     extras_require=extras_require,


### PR DESCRIPTION
This is a tiny fix that adds an additional alias in the setup.py file to fix https://github.com/jkbrzt/httpie/issues/505
