### PR TITLE
#427 preserve JSON key order in output if supported

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -1054,8 +1054,9 @@ values).
 Also, the following formatting is applied:
 
 * HTTP headers are sorted by name.
-* JSON data is indented, sorted by keys, and unicode escapes are converted
-  to the characters they represent.
+* JSON data is indented, and unicode escapes are converted to the characters
+  they represent. Objects will retain their key ordering from the response body,
+  except on Python 2.6 where keys will be sorted alphabetically.
 
 One of these options can be used to control output processing:
 
@@ -1551,4 +1552,3 @@ have contributed.
 .. |gitter| image:: https://badges.gitter.im/jkbrzt/httpie.svg
     :target: https://gitter.im/jkbrzt/httpie
     :alt: Chat on Gitter
-

--- a/httpie/output/formatters/json.py
+++ b/httpie/output/formatters/json.py
@@ -1,7 +1,7 @@
 from __future__ import absolute_import
-import json
 
 from httpie.plugins import FormatterPlugin
+from httpie.utils import load_json_preserve_order, pretty_print_json
 
 
 DEFAULT_INDENT = 4
@@ -18,16 +18,9 @@ class JSONFormatter(FormatterPlugin):
         if (self.kwargs['explicit_json'] or
                 any(token in mime for token in maybe_json)):
             try:
-                obj = json.loads(body)
+                obj = load_json_preserve_order(body)
             except ValueError:
                 pass  # Invalid JSON, ignore.
             else:
-                # Indent, sort keys by name, and avoid
-                # unicode escapes to improve readability.
-                body = json.dumps(
-                    obj=obj,
-                    sort_keys=True,
-                    ensure_ascii=False,
-                    indent=DEFAULT_INDENT
-                )
+                body = pretty_print_json(obj, DEFAULT_INDENT)
         return body

--- a/httpie/utils.py
+++ b/httpie/utils.py
@@ -3,11 +3,21 @@ import json
 
 from httpie.compat import is_py26, OrderedDict
 
-
 def load_json_preserve_order(s):
     if is_py26:
         return json.loads(s)
     return json.loads(s, object_pairs_hook=OrderedDict)
+
+
+def pretty_print_json(obj, indent):
+    # Indent, sort keys by name, and avoid
+    # unicode escapes to improve readability.
+    return json.dumps(
+        obj=obj,
+        sort_keys=is_py26,
+        ensure_ascii=False,
+        indent=indent
+    )
 
 
 def repr_dict_nice(d):

--- a/httpie/utils.py
+++ b/httpie/utils.py
@@ -3,6 +3,7 @@ import json
 
 from httpie.compat import is_py26, OrderedDict
 
+
 def load_json_preserve_order(s):
     if is_py26:
         return json.loads(s)


### PR DESCRIPTION
Because 2.6 does not support object_pairs_hook, this behaviour only kicks in on 2.7 or later.
