### PR TITLE
Read arguments as Unicode on Python 2 on Windows

### DIFF
--- a/httpie/__main__.py
+++ b/httpie/__main__.py
@@ -6,7 +6,7 @@ import sys
 
 if sys.platform.startswith('win') and sys.version_info[0] == 2:
     # https://github.com/jakubroztocil/httpie/issues/572
-    
+
     # https://stackoverflow.com/questions/846850/read-unicode-characters-from-command-line-arguments-in-python-2-x-on-windows/846931#846931
     def win32_unicode_argv():
         """Use shell32.GetCommandLineArgvW to get sys.argv as a list of
@@ -44,7 +44,7 @@ else:
 def main(argv):
     try:
         from .core import main
-        sys.exit(main(argv))
+        sys.exit(main(argv[1:]))
     except KeyboardInterrupt:
         from . import ExitStatus
         sys.exit(ExitStatus.ERROR_CTRL_C)

--- a/httpie/__main__.py
+++ b/httpie/__main__.py
@@ -4,15 +4,51 @@
 """
 import sys
 
+if sys.platform.startswith('win') and sys.version_info[0] == 2:
+    # https://github.com/jakubroztocil/httpie/issues/572
+    
+    # https://stackoverflow.com/questions/846850/read-unicode-characters-from-command-line-arguments-in-python-2-x-on-windows/846931#846931
+    def win32_unicode_argv():
+        """Use shell32.GetCommandLineArgvW to get sys.argv as a list of
+        Unicode strings.
 
-def main():
+        Versions 2.x of Python don't support Unicode in sys.argv on
+        Windows, with the underlying Windows API instead replacing
+        multi-byte characters with '?'.
+        """
+
+        from ctypes import POINTER, byref, cdll, c_int, windll
+        from ctypes.wintypes import LPCWSTR, LPWSTR
+
+        GetCommandLineW = cdll.kernel32.GetCommandLineW
+        GetCommandLineW.argtypes = []
+        GetCommandLineW.restype = LPCWSTR
+
+        CommandLineToArgvW = windll.shell32.CommandLineToArgvW
+        CommandLineToArgvW.argtypes = [LPCWSTR, POINTER(c_int)]
+        CommandLineToArgvW.restype = POINTER(LPWSTR)
+
+        cmd = GetCommandLineW()
+        argc = c_int(0)
+        argv = CommandLineToArgvW(cmd, byref(argc))
+        if argc.value > 0:
+            # Remove Python executable and commands if present
+            start = argc.value - len(sys.argv)
+            return [argv[i] for i in xrange(start, argc.value)]
+
+    argv = win32_unicode_argv()
+else:
+    argv = sys.argv
+
+
+def main(argv):
     try:
         from .core import main
-        sys.exit(main())
+        sys.exit(main(argv))
     except KeyboardInterrupt:
         from . import ExitStatus
         sys.exit(ExitStatus.ERROR_CTRL_C)
 
 
 if __name__ == '__main__':
-    main()
+    main(argv)


### PR DESCRIPTION
Need it for international domain names, such as 115.бел

Fixes issue #572 
