### PR TITLE
List DNF as Fedora package manager in README

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -83,7 +83,12 @@ system package manager, for example:
 
 .. code-block:: bash
 
-    # Fedora, CentOS, RHEL, …
+    # Fedora
+    $ dnf install httpie
+
+.. code-block:: bash
+
+    # CentOS, RHEL, ...
     $ yum install httpie
 
 .. code-block:: bash


### PR DESCRIPTION
DNF replaced YUM as the default package manager as of Fedora 22.