### PR TITLE
Prevent TestEnvironment class from emitting warnings.

### DIFF
--- a/AUTHORS.rst
+++ b/AUTHORS.rst
@@ -36,5 +36,5 @@ Patches and ideas
 * `Dennis Brakhane <https://github.com/brakhane>`_
 * `Matt Layman <https://github.com/mblayman>`_
 * `Edward Yang <https://github.com/honorabrutroll>`_
-
+* `Martin Moore <https://github.com/mjmoore>`_
 

--- a/tests/test_auth.py
+++ b/tests/test_auth.py
@@ -2,7 +2,7 @@
 import mock
 import pytest
 
-from utils import http, add_auth, HTTP_OK, TestEnvironment
+from utils import http, add_auth, HTTP_OK, _TestEnvironment
 import httpie.input
 import httpie.cli
 
@@ -58,7 +58,7 @@ def test_only_username_in_url(url):
     https://github.com/jakubroztocil/httpie/issues/242
 
     """
-    args = httpie.cli.parser.parse_args(args=[url], env=TestEnvironment())
+    args = httpie.cli.parser.parse_args(args=[url], env=_TestEnvironment())
     assert args.auth
     assert args.auth.username == 'username'
     assert args.auth.password == ''

--- a/tests/test_binary.py
+++ b/tests/test_binary.py
@@ -2,14 +2,14 @@
 from fixtures import BIN_FILE_PATH, BIN_FILE_CONTENT, BIN_FILE_PATH_ARG
 from httpie.compat import urlopen
 from httpie.output.streams import BINARY_SUPPRESSED_NOTICE
-from utils import TestEnvironment, http
+from utils import _TestEnvironment, http
 
 
 class TestBinaryRequestData:
 
     def test_binary_stdin(self, httpbin):
         with open(BIN_FILE_PATH, 'rb') as stdin:
-            env = TestEnvironment(
+            env = _TestEnvironment(
                 stdin=stdin,
                 stdin_isatty=False,
                 stdout_isatty=False
@@ -18,13 +18,13 @@ class TestBinaryRequestData:
             assert r == BIN_FILE_CONTENT
 
     def test_binary_file_path(self, httpbin):
-        env = TestEnvironment(stdin_isatty=True, stdout_isatty=False)
+        env = _TestEnvironment(stdin_isatty=True, stdout_isatty=False)
         r = http('--print=B', 'POST', httpbin.url + '/post',
                  '@' + BIN_FILE_PATH_ARG, env=env, )
         assert r == BIN_FILE_CONTENT
 
     def test_binary_file_form(self, httpbin):
-        env = TestEnvironment(stdin_isatty=True, stdout_isatty=False)
+        env = _TestEnvironment(stdin_isatty=True, stdout_isatty=False)
         r = http('--print=B', '--form', 'POST', httpbin.url + '/post',
                  'test@' + BIN_FILE_PATH_ARG, env=env)
         assert bytes(BIN_FILE_CONTENT) in bytes(r)
@@ -44,12 +44,12 @@ class TestBinaryResponseData:
         assert BINARY_SUPPRESSED_NOTICE.decode() in r
 
     def test_binary_suppresses_when_not_terminal_but_pretty(self):
-        env = TestEnvironment(stdin_isatty=True, stdout_isatty=False)
+        env = _TestEnvironment(stdin_isatty=True, stdout_isatty=False)
         r = http('--pretty=all', 'GET', self.url,
                  env=env)
         assert BINARY_SUPPRESSED_NOTICE.decode() in r
 
     def test_binary_included_and_correct_when_suitable(self):
-        env = TestEnvironment(stdin_isatty=True, stdout_isatty=False)
+        env = _TestEnvironment(stdin_isatty=True, stdout_isatty=False)
         r = http('GET', self.url, env=env)
         assert r == self.bindata

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -10,7 +10,7 @@ from httpie import input
 from httpie.input import KeyValue, KeyValueArgType, DataDict
 from httpie import ExitStatus
 from httpie.cli import parser
-from utils import TestEnvironment, http, HTTP_OK
+from utils import _TestEnvironment, http, HTTP_OK
 from fixtures import (
     FILE_PATH_ARG, JSON_FILE_PATH_ARG,
     JSON_FILE_CONTENT, FILE_CONTENT, FILE_PATH
@@ -161,44 +161,44 @@ class TestQuerystring:
 
 class TestLocalhostShorthand:
     def test_expand_localhost_shorthand(self):
-        args = parser.parse_args(args=[':'], env=TestEnvironment())
+        args = parser.parse_args(args=[':'], env=_TestEnvironment())
         assert args.url == 'http://localhost'
 
     def test_expand_localhost_shorthand_with_slash(self):
-        args = parser.parse_args(args=[':/'], env=TestEnvironment())
+        args = parser.parse_args(args=[':/'], env=_TestEnvironment())
         assert args.url == 'http://localhost/'
 
     def test_expand_localhost_shorthand_with_port(self):
-        args = parser.parse_args(args=[':3000'], env=TestEnvironment())
+        args = parser.parse_args(args=[':3000'], env=_TestEnvironment())
         assert args.url == 'http://localhost:3000'
 
     def test_expand_localhost_shorthand_with_path(self):
-        args = parser.parse_args(args=[':/path'], env=TestEnvironment())
+        args = parser.parse_args(args=[':/path'], env=_TestEnvironment())
         assert args.url == 'http://localhost/path'
 
     def test_expand_localhost_shorthand_with_port_and_slash(self):
-        args = parser.parse_args(args=[':3000/'], env=TestEnvironment())
+        args = parser.parse_args(args=[':3000/'], env=_TestEnvironment())
         assert args.url == 'http://localhost:3000/'
 
     def test_expand_localhost_shorthand_with_port_and_path(self):
-        args = parser.parse_args(args=[':3000/path'], env=TestEnvironment())
+        args = parser.parse_args(args=[':3000/path'], env=_TestEnvironment())
         assert args.url == 'http://localhost:3000/path'
 
     def test_dont_expand_shorthand_ipv6_as_shorthand(self):
-        args = parser.parse_args(args=['::1'], env=TestEnvironment())
+        args = parser.parse_args(args=['::1'], env=_TestEnvironment())
         assert args.url == 'http://::1'
 
     def test_dont_expand_longer_ipv6_as_shorthand(self):
         args = parser.parse_args(
             args=['::ffff:c000:0280'],
-            env=TestEnvironment()
+            env=_TestEnvironment()
         )
         assert args.url == 'http://::ffff:c000:0280'
 
     def test_dont_expand_full_ipv6_as_shorthand(self):
         args = parser.parse_args(
             args=['0000:0000:0000:0000:0000:0000:0000:0001'],
-            env=TestEnvironment()
+            env=_TestEnvironment()
         )
         assert args.url == 'http://0000:0000:0000:0000:0000:0000:0000:0001'
 
@@ -215,7 +215,7 @@ class TestArgumentParser:
         self.parser.args.items = []
         self.parser.args.ignore_stdin = False
 
-        self.parser.env = TestEnvironment()
+        self.parser.env = _TestEnvironment()
 
         self.parser._guess_method()
 
@@ -229,7 +229,7 @@ class TestArgumentParser:
         self.parser.args.url = 'http://example.com/'
         self.parser.args.items = []
         self.parser.args.ignore_stdin = False
-        self.parser.env = TestEnvironment()
+        self.parser.env = _TestEnvironment()
 
         self.parser._guess_method()
 
@@ -243,7 +243,7 @@ class TestArgumentParser:
         self.parser.args.url = 'data=field'
         self.parser.args.items = []
         self.parser.args.ignore_stdin = False
-        self.parser.env = TestEnvironment()
+        self.parser.env = _TestEnvironment()
         self.parser._guess_method()
 
         assert self.parser.args.method == 'POST'
@@ -262,7 +262,7 @@ class TestArgumentParser:
         self.parser.args.items = []
         self.parser.args.ignore_stdin = False
 
-        self.parser.env = TestEnvironment()
+        self.parser.env = _TestEnvironment()
 
         self.parser._guess_method()
 
@@ -285,7 +285,7 @@ class TestArgumentParser:
         ]
         self.parser.args.ignore_stdin = False
 
-        self.parser.env = TestEnvironment()
+        self.parser.env = _TestEnvironment()
 
         self.parser._guess_method()
 
@@ -314,7 +314,7 @@ class TestIgnoreStdin:
 
     def test_ignore_stdin(self, httpbin):
         with open(FILE_PATH) as f:
-            env = TestEnvironment(stdin=f, stdin_isatty=False)
+            env = _TestEnvironment(stdin=f, stdin_isatty=False)
             r = http('--ignore-stdin', '--verbose', httpbin.url + '/get',
                      env=env)
         assert HTTP_OK in r

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -1,8 +1,8 @@
-from utils import TestEnvironment, http
+from utils import _TestEnvironment, http
 
 
 def test_default_options(httpbin):
-    env = TestEnvironment()
+    env = _TestEnvironment()
     env.config['default_options'] = ['--form']
     env.config.save()
     r = http(httpbin.url + '/post', 'foo=bar', env=env)
@@ -10,7 +10,7 @@ def test_default_options(httpbin):
 
 
 def test_default_options_overwrite(httpbin):
-    env = TestEnvironment()
+    env = _TestEnvironment()
     env.config['default_options'] = ['--form']
     env.config.save()
     r = http('--json', httpbin.url + '/post', 'foo=bar', env=env)
@@ -18,7 +18,7 @@ def test_default_options_overwrite(httpbin):
 
 
 def test_migrate_implicit_content_type():
-    config = TestEnvironment().config
+    config = _TestEnvironment().config
 
     config['implicit_content_type'] = 'json'
     config.save()

--- a/tests/test_defaults.py
+++ b/tests/test_defaults.py
@@ -3,7 +3,7 @@ Tests for the provided defaults regarding HTTP method, and --json vs. --form.
 
 """
 from httpie.client import JSON_ACCEPT
-from utils import TestEnvironment, http, HTTP_OK
+from utils import _TestEnvironment, http, HTTP_OK
 from fixtures import FILE_PATH
 
 
@@ -29,7 +29,7 @@ class TestImplicitHTTPMethod:
 
     def test_implicit_POST_stdin(self, httpbin):
         with open(FILE_PATH) as f:
-            env = TestEnvironment(stdin_isatty=False, stdin=f)
+            env = _TestEnvironment(stdin_isatty=False, stdin=f)
             r = http('--form', httpbin.url + '/post', env=env)
         assert HTTP_OK in r
 
@@ -97,11 +97,11 @@ class TestAutoContentTypeAndAcceptHeaders:
         assert '"Content-Type": "application/xml"' in r
 
     def test_print_only_body_when_stdout_redirected_by_default(self, httpbin):
-        env = TestEnvironment(stdin_isatty=True, stdout_isatty=False)
+        env = _TestEnvironment(stdin_isatty=True, stdout_isatty=False)
         r = http('GET', httpbin.url + '/get', env=env)
         assert 'HTTP/' not in r
 
     def test_print_overridable_when_stdout_redirected(self, httpbin):
-        env = TestEnvironment(stdin_isatty=True, stdout_isatty=False)
+        env = _TestEnvironment(stdin_isatty=True, stdout_isatty=False)
         r = http('--print=h', 'GET', httpbin.url + '/get', env=env)
         assert HTTP_OK in r

--- a/tests/test_downloads.py
+++ b/tests/test_downloads.py
@@ -10,7 +10,7 @@ from httpie.downloads import (
     parse_content_range, filename_from_content_disposition, filename_from_url,
     get_unique_filename, ContentRangeError, Downloader,
 )
-from utils import http, TestEnvironment
+from utils import http, _TestEnvironment
 
 
 class Response(object):
@@ -123,7 +123,7 @@ class TestDownloads:
     def test_actual_download(self, httpbin_both, httpbin):
         robots_txt = '/robots.txt'
         body = urlopen(httpbin + robots_txt).read().decode()
-        env = TestEnvironment(stdin_isatty=True, stdout_isatty=False)
+        env = _TestEnvironment(stdin_isatty=True, stdout_isatty=False)
         r = http('--download', httpbin_both.url + robots_txt, env=env)
         assert 'Downloading' in r.stderr
         assert '[K' in r.stderr

--- a/tests/test_exit_status.py
+++ b/tests/test_exit_status.py
@@ -1,7 +1,7 @@
 import mock
 
 from httpie import ExitStatus
-from utils import TestEnvironment, http, HTTP_OK
+from utils import _TestEnvironment, http, HTTP_OK
 
 
 def test_keyboard_interrupt_during_arg_parsing_exit_status(httpbin):
@@ -40,7 +40,7 @@ def test_timeout_exit_status(httpbin):
 
 def test_3xx_check_status_exits_3_and_stderr_when_stdout_redirected(
         httpbin):
-    env = TestEnvironment(stdout_isatty=False)
+    env = _TestEnvironment(stdout_isatty=False)
     r = http('--check-status', '--headers',
              'GET', httpbin.url + '/status/301',
              env=env, error_exit_ok=True)

--- a/tests/test_httpie.py
+++ b/tests/test_httpie.py
@@ -2,7 +2,7 @@
 import pytest
 
 from httpie.input import ParseError
-from utils import TestEnvironment, http, HTTP_OK
+from utils import _TestEnvironment, http, HTTP_OK
 from fixtures import FILE_PATH, FILE_CONTENT
 
 import httpie
@@ -64,7 +64,7 @@ def test_POST_form_multiple_values(httpbin_both):
 
 def test_POST_stdin(httpbin_both):
     with open(FILE_PATH) as f:
-        env = TestEnvironment(stdin=f, stdin_isatty=False)
+        env = _TestEnvironment(stdin=f, stdin_isatty=False)
         r = http('--form', 'POST', httpbin_both + '/post', env=env)
     assert HTTP_OK in r
     assert FILE_CONTENT in r

--- a/tests/test_output.py
+++ b/tests/test_output.py
@@ -3,7 +3,7 @@ from tempfile import gettempdir
 
 import pytest
 
-from utils import TestEnvironment, http, HTTP_OK, COLOR, CRLF
+from utils import _TestEnvironment, http, HTTP_OK, COLOR, CRLF
 from httpie import ExitStatus
 from httpie.compat import urlopen
 from httpie.output.formatters.colors import get_lexer
@@ -15,7 +15,7 @@ def test_output_option(httpbin, stdout_isatty):
     url = httpbin + '/robots.txt'
 
     r = http('--output', output_filename, url,
-             env=TestEnvironment(stdout_isatty=stdout_isatty))
+             env=_TestEnvironment(stdout_isatty=stdout_isatty))
     assert r == ''
 
     expected_body = urlopen(url).read().decode()
@@ -86,7 +86,7 @@ class TestPrettyOptions:
     """Test the --pretty flag handling."""
 
     def test_pretty_enabled_by_default(self, httpbin):
-        env = TestEnvironment(colors=256)
+        env = _TestEnvironment(colors=256)
         r = http('GET', httpbin.url + '/get', env=env)
         assert COLOR in r
 
@@ -95,7 +95,7 @@ class TestPrettyOptions:
         assert COLOR not in r
 
     def test_force_pretty(self, httpbin):
-        env = TestEnvironment(stdout_isatty=False, colors=256)
+        env = _TestEnvironment(stdout_isatty=False, colors=256)
         r = http('--pretty=all', 'GET', httpbin.url + '/get', env=env, )
         assert COLOR in r
 
@@ -108,13 +108,13 @@ class TestPrettyOptions:
         match any lexer.
 
         """
-        env = TestEnvironment(colors=256)
+        env = _TestEnvironment(colors=256)
         r = http('--print=B', '--pretty=all', httpbin.url + '/post',
                  'Content-Type:text/foo+json', 'a=b', env=env)
         assert COLOR in r
 
     def test_colors_option(self, httpbin):
-        env = TestEnvironment(colors=256)
+        env = _TestEnvironment(colors=256)
         r = http('--print=B', '--pretty=colors',
                  'GET', httpbin.url + '/get', 'a=b',
                  env=env)
@@ -123,7 +123,7 @@ class TestPrettyOptions:
         assert COLOR in r
 
     def test_format_option(self, httpbin):
-        env = TestEnvironment(colors=256)
+        env = _TestEnvironment(colors=256)
         r = http('--print=B', '--pretty=format',
                  'GET', httpbin.url + '/get', 'a=b',
                  env=env)

--- a/tests/test_sessions.py
+++ b/tests/test_sessions.py
@@ -7,7 +7,7 @@ from tempfile import gettempdir
 import pytest
 
 from httpie.plugins.builtin import HTTPBasicAuth
-from utils import TestEnvironment, mk_config_dir, http, HTTP_OK
+from utils import _TestEnvironment, mk_config_dir, http, HTTP_OK
 from fixtures import UNICODE
 
 
@@ -29,7 +29,7 @@ class SessionTestBase(object):
         for session files being reused.
 
         """
-        return TestEnvironment(config_dir=self.config_dir)
+        return _TestEnvironment(config_dir=self.config_dir)
 
 
 class TestSessionFlow(SessionTestBase):

--- a/tests/test_stream.py
+++ b/tests/test_stream.py
@@ -2,7 +2,7 @@ import pytest
 
 from httpie.compat import is_windows
 from httpie.output.streams import BINARY_SUPPRESSED_NOTICE
-from utils import http, TestEnvironment
+from utils import http, _TestEnvironment
 from fixtures import BIN_FILE_CONTENT, BIN_FILE_PATH
 
 
@@ -14,7 +14,7 @@ from fixtures import BIN_FILE_CONTENT, BIN_FILE_PATH
 def test_pretty_redirected_stream(httpbin):
     """Test that --stream works with prettified redirected output."""
     with open(BIN_FILE_PATH, 'rb') as f:
-        env = TestEnvironment(colors=256, stdin=f,
+        env = _TestEnvironment(colors=256, stdin=f,
                               stdin_isatty=False,
                               stdout_isatty=False)
         r = http('--verbose', '--pretty=all', '--stream', 'GET',
@@ -26,7 +26,7 @@ def test_encoded_stream(httpbin):
     """Test that --stream works with non-prettified
     redirected terminal output."""
     with open(BIN_FILE_PATH, 'rb') as f:
-        env = TestEnvironment(stdin=f, stdin_isatty=False)
+        env = _TestEnvironment(stdin=f, stdin_isatty=False)
         r = http('--pretty=none', '--stream', '--verbose', 'GET',
                  httpbin.url + '/get', env=env)
     assert BINARY_SUPPRESSED_NOTICE.decode() in r
@@ -36,7 +36,7 @@ def test_redirected_stream(httpbin):
     """Test that --stream works with non-prettified
     redirected terminal output."""
     with open(BIN_FILE_PATH, 'rb') as f:
-        env = TestEnvironment(stdout_isatty=False,
+        env = _TestEnvironment(stdout_isatty=False,
                               stdin_isatty=False,
                               stdin=f)
         r = http('--pretty=none', '--stream', '--verbose', 'GET',

--- a/tests/test_uploads.py
+++ b/tests/test_uploads.py
@@ -3,7 +3,7 @@ import os
 import pytest
 
 from httpie.input import ParseError
-from utils import TestEnvironment, http, HTTP_OK
+from utils import _TestEnvironment, http, HTTP_OK
 from fixtures import FILE_PATH_ARG, FILE_PATH, FILE_CONTENT
 
 
@@ -62,14 +62,14 @@ class TestRequestBodyFromFilePath:
 
     def test_request_body_from_file_by_path_no_field_name_allowed(
             self, httpbin):
-        env = TestEnvironment(stdin_isatty=True)
+        env = _TestEnvironment(stdin_isatty=True)
         r = http('POST', httpbin.url + '/post', 'field-name@' + FILE_PATH_ARG,
                  env=env, error_exit_ok=True)
         assert 'perhaps you meant --form?' in r.stderr
 
     def test_request_body_from_file_by_path_no_data_items_allowed(
             self, httpbin):
-        env = TestEnvironment(stdin_isatty=False)
+        env = _TestEnvironment(stdin_isatty=False)
         r = http('POST', httpbin.url + '/post', '@' + FILE_PATH_ARG, 'foo=bar',
                  env=env, error_exit_ok=True)
         assert 'cannot be mixed' in r.stderr

--- a/tests/test_windows.py
+++ b/tests/test_windows.py
@@ -4,7 +4,7 @@ import tempfile
 import pytest
 from httpie.context import Environment
 
-from utils import TestEnvironment, http
+from utils import _TestEnvironment, http
 from httpie.compat import is_windows
 
 
@@ -20,7 +20,7 @@ class TestWindowsOnly:
 
 class TestFakeWindows:
     def test_output_file_pretty_not_allowed_on_windows(self, httpbin):
-        env = TestEnvironment(is_windows=True)
+        env = _TestEnvironment(is_windows=True)
         output_file = os.path.join(
             tempfile.gettempdir(),
             self.test_output_file_pretty_not_allowed_on_windows.__name__

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -33,7 +33,7 @@ def add_auth(url, auth):
     return proto + '://' + auth + '@' + rest
 
 
-class TestEnvironment(Environment):
+class _TestEnvironment(Environment):
     """Environment subclass with reasonable defaults for testing."""
     colors = 0
     stdin_isatty = True,
@@ -51,7 +51,7 @@ class TestEnvironment(Environment):
                 mode='w+t',
                 prefix='httpie_stderr'
             )
-        super(TestEnvironment, self).__init__(**kwargs)
+        super(_TestEnvironment, self).__init__(**kwargs)
         self._delete_config_dir = False
 
     @property
@@ -59,7 +59,7 @@ class TestEnvironment(Environment):
         if not self.config_dir.startswith(tempfile.gettempdir()):
             self.config_dir = mk_config_dir()
             self._delete_config_dir = True
-        return super(TestEnvironment, self).config
+        return super(_TestEnvironment, self).config
 
     def cleanup(self):
         if self._delete_config_dir:
@@ -183,7 +183,7 @@ def http(*args, **kwargs):
     error_exit_ok = kwargs.pop('error_exit_ok', False)
     env = kwargs.get('env')
     if not env:
-        env = kwargs['env'] = TestEnvironment()
+        env = kwargs['env'] = _TestEnvironment()
 
     stdout = env.stdout
     stderr = env.stderr


### PR DESCRIPTION
Test runners pick up the `TestEnvironment` class as a valid test, then emiiting a warning as the class has its own `__init__` method defined. To prevent this, the class is prepended with a single underscore.