### PR TITLE
Clarify error message

### DIFF
--- a/httpie/input.py
+++ b/httpie/input.py
@@ -302,7 +302,8 @@ class HTTPieArgumentParser(ArgumentParser):
         """
         if self.args.data:
             self.error('Request body (from stdin or a file) and request '
-                       'data (key=value) cannot be mixed.')
+                       'data (key=value) cannot be mixed. Pass '
+                       '--ignore-stdin to let key/value take priority.')
         self.args.data = getattr(fd, 'buffer', fd).read()
 
     def _guess_method(self):


### PR DESCRIPTION
#150 was addressed by adding `--ignore-stdin`, but the error message wasn't clarified to mention that option.