### PR TITLE
Fix Travis Build by removing 2.6

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -10,7 +10,6 @@ env:
     - NEWEST_PYTHON=3.6
 
 python:
-  - 2.6
   - 2.7
   - pypy
   - 3.4


### PR DESCRIPTION
A dependency has stopped supporting 2.6, this pull request removes 2.6 from the build requirements:
```
Collecting ruamel.yaml (from maya->Flask-Common->httpbin->pytest-httpbin>=0.0.6->-r requirements-dev.txt (line 5))
  Downloading ruamel.yaml-0.15.34.tar.gz (260kB)
    100% |████████████████████████████████| 266kB 3.9MB/s 
    Complete output from command python setup.py egg_info:
    minimum python version(s): [(2, 7), (3, 3)]
```
Python 2.6 is deprecated by the PSF.