### PR TITLE
fix env version attribute

### DIFF
--- a/httpie/config.py
+++ b/httpie/config.py
@@ -104,7 +104,7 @@ class Config(BaseConfigDict):
         try:
             implicit_content_type = self.pop('implicit_content_type')
         except KeyError:
-            pass
+            self.save()
         else:
             if implicit_content_type == 'form':
                 self['default_options'].insert(0, '--form')

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -1,4 +1,6 @@
+from httpie import __version__
 from utils import TestEnvironment, http
+from httpie.context import Environment
 
 
 def test_default_options(httpbin):
@@ -31,3 +33,8 @@ def test_migrate_implicit_content_type():
     config.load()
     assert 'implicit_content_type' not in config
     assert config['default_options'] == ['--form']
+
+
+def test_current_version():
+    version = Environment().config['__meta__']['httpie']
+    assert version == __version__


### PR DESCRIPTION
if multiple versions of `httpie` are installed on a machine, the `env.config.__meta__.httpie` attribute doesn't have the current version from `__init__.__version__`
this can cause problems if the `env` object is used to make decisions to enforce compatibility based on the httpie version.