### PR TITLE
Changes to allow for a standalone executable

### DIFF
--- a/httpie/__main__.py
+++ b/httpie/__main__.py
@@ -12,6 +12,9 @@ def main():
     except KeyboardInterrupt:
         from . import ExitStatus
         sys.exit(ExitStatus.ERROR_CTRL_C)
+    except ModuleNotFoundError:
+        from core import main
+        sys.exit(main())
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
If you attempt to execute `__main__.py` directly, you get:
```
Traceback (most recent call last):
  File "__main__.py", line 18, in <module>
    main()
  File "__main__.py", line 10, in main
    from .core import main
ModuleNotFoundError: No module named '__main__.core'; '__main__' is not a package
```

However, if you add to `__main__.py` in `main()`:
```
except ModuleNotFoundError:
    from core import main
    sys.exit(main())
```
And attempt to execute it again, the program boots up like normal:
```
usage: __main__.py [--json] [--form] [--pretty {all,colors,format,none}]
                   [--style STYLE] [--print WHAT] [--headers] [--body]
                   [--verbose] [--all] [--history-print WHAT] [--stream]
                   [--output FILE] [--download] [--continue]
                   [--session SESSION_NAME_OR_PATH | --session-read-only SESSION_NAME_OR_PATH]
                   [--auth USER[:PASS]] [--auth-type {basic,digest}]
                   [--proxy PROTOCOL:PROXY_URL] [--follow]
                   [--max-redirects MAX_REDIRECTS] [--timeout SECONDS]
                   [--check-status] [--verify VERIFY]
                   [--ssl {ssl2.3,ssl3,tls1,tls1.1,tls1.2}] [--cert CERT]
                   [--cert-key CERT_KEY] [--ignore-stdin] [--help] [--version]
                   [--traceback] [--default-scheme DEFAULT_SCHEME] [--debug]
                   [METHOD] URL [REQUEST_ITEM [REQUEST_ITEM ...]]
__main__.py: error: the following arguments are required: URL
```
If it's capable of being executed like so, then it can be frozen too as well, right? I used [PyInstaller](http://www.pyinstaller.org/).
```
pyinstaller --onefile -n http --hidden-import=core __main__.py
```

- `--onefile` packages it into a singular file instead of a folder.
- `-n http` names the executable "http" because it would have been named `__main__.exe` otherwise.
- `--hidden-import=core` is there because the executable refused to recognise the core until I specifically provided it.

All the steps to compile HTTPie:
1. `git clone` the repository.
2. From within the directory, execute `python setup.py build`.
3. The built library should be in `httpie\build\lib`.
4. Enter that directory and execute `pyinstaller --onefile -n http --hidden-import=core __main__.py`.
5. A packaged executable should be in a folder named `dist`.

P.S. First attempt at a pull request ever! How did I do?