### PR TITLE
Support using styles from Pygments plugins

### DIFF
--- a/httpie/output/formatters/colors.py
+++ b/httpie/output/formatters/colors.py
@@ -16,7 +16,7 @@ from httpie.compat import is_windows
 from httpie.plugins import FormatterPlugin
 
 
-AVAILABLE_STYLES = set(pygments.styles.STYLE_MAP.keys())
+AVAILABLE_STYLES = set(pygments.styles.get_all_styles())
 AVAILABLE_STYLES.add('solarized')
 
 # This is the native style provided by the terminal emulator color scheme


### PR DESCRIPTION
`pygments.styles.STYLE_MAP` contains only styles built directly into Pygments library. To list all available styles (including styles registered by plugins), one should use `get_all_styles` generator.

For respective Pygments documentation, see: http://pygments.org/docs/styles/#getting-a-list-of-available-styles