### PR TITLE
Add optional compression of the request's content

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -44,9 +44,9 @@ matrix:
       language: generic
       env:
         # Latest Python 3.x from Homebrew
-        - TOXENV=py37  # <= needs to be kept up-to-date to reflect latest minor version
+        - TOXENV=py36  # <= needs to be kept up-to-date to reflect latest minor version
         - BREW_PYTHON_PACKAGE=python@3
-    # Travis Python 3.7 must run sudo on 
+    # Travis Python 3.7 must run sudo on
     - os: linux
       python: 3.7
       env: TOXENV=py37

--- a/AUTHORS.rst
+++ b/AUTHORS.rst
@@ -36,5 +36,5 @@ Patches and ideas
 * `Dennis Brakhane <https://github.com/brakhane>`_
 * `Matt Layman <https://github.com/mblayman>`_
 * `Edward Yang <https://github.com/honorabrutroll>`_
-
+* `Aleksandr Vinokurov <https://github.com/aleksandr-vin>`_
 

--- a/httpie/cli.py
+++ b/httpie/cli.py
@@ -183,6 +183,29 @@ content_type.add_argument(
 
 
 #######################################################################
+# Content processing.
+#######################################################################
+
+content_processing = parser.add_argument_group(
+    title='Content Processing Options',
+    description=None
+)
+
+content_processing.add_argument(
+    '--compress', '-x',
+    action='count',
+    help="""
+    Content compressed (encoded) with Deflate algorithm.
+    The Content-Encoding header is set to deflate.
+    
+    Compression is skipped if it appears that compression ratio is
+    negative. Compression can be forced by repeating the argument. 
+
+    """
+)
+
+
+#######################################################################
 # Output processing
 #######################################################################
 

--- a/httpie/cli.py
+++ b/httpie/cli.py
@@ -197,9 +197,9 @@ content_processing.add_argument(
     help="""
     Content compressed (encoded) with Deflate algorithm.
     The Content-Encoding header is set to deflate.
-    
+
     Compression is skipped if it appears that compression ratio is
-    negative. Compression can be forced by repeating the argument. 
+    negative. Compression can be forced by repeating the argument.
 
     """
 )

--- a/httpie/client.py
+++ b/httpie/client.py
@@ -43,6 +43,7 @@ class HTTPieHTTPAdapter(HTTPAdapter):
         kwargs['ssl_version'] = self._ssl_version
         super(HTTPieHTTPAdapter, self).init_poolmanager(*args, **kwargs)
 
+
 class ContentCompressionHttpAdapter(HTTPAdapter):
 
     def __init__(self, compress, **kwargs):

--- a/httpie/client.py
+++ b/httpie/client.py
@@ -53,7 +53,11 @@ class ContentCompressionHttpAdapter(HTTPAdapter):
     def send(self, request, **kwargs):
         if request.body and self.compress > 0:
             deflater = zlib.compressobj()
-            deflated_data = deflater.compress(request.body)
+            print(">>>> " + str(type(request.body)))
+            if isinstance(request.body, bytes):
+                deflated_data = deflater.compress(request.body)
+            else:
+                deflated_data = deflater.compress(request.body.encode())
             deflated_data += deflater.flush()
             if len(deflated_data) < len(request.body) or self.compress > 1:
                 request.body = deflated_data

--- a/httpie/client.py
+++ b/httpie/client.py
@@ -53,7 +53,6 @@ class ContentCompressionHttpAdapter(HTTPAdapter):
     def send(self, request, **kwargs):
         if request.body and self.compress > 0:
             deflater = zlib.compressobj()
-            print(">>>> " + str(type(request.body)))
             if isinstance(request.body, bytes):
                 deflated_data = deflater.compress(request.body)
             else:


### PR DESCRIPTION
This option allows compression of the files and/or data during uploading.

Examples:

    http --form --compress POST https://localhost/upload csv@./very-big.csv

    http -x -x POST https://localhost/upload foo=bar

    cat /var/log/system.log | http -x POST https://localhost/upload
