### PR TITLE
fixed wrong value in bash command

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -417,7 +417,7 @@ token ``--`` to prevent confusion with ``--arguments``:
 
 .. code-block:: bash
 
-    $ http httpbin.org/post  --  -name-starting-with-dash=foo -Unusual-Header:bar
+    $ http httpbin.org/post  --  -name-starting-with-dash=value -Unusual-Header:bar
 
 .. code-block:: http
 


### PR DESCRIPTION
It should be 'value' not 'foo' to get the corresponding output