### PR TITLE
Add XMLFormatter

### DIFF
--- a/AUTHORS.rst
+++ b/AUTHORS.rst
@@ -36,5 +36,6 @@ Patches and ideas
 * `Dennis Brakhane <https://github.com/brakhane>`_
 * `Matt Layman <https://github.com/mblayman>`_
 * `Edward Yang <https://github.com/honorabrutroll>`_
+* `Rohit Sehgal <https://github.com/r0hi7>`_
 
 

--- a/httpie/output/formatters/xml.py
+++ b/httpie/output/formatters/xml.py
@@ -1,0 +1,20 @@
+from __future__ import absolute_import
+
+import xml.dom.minidom
+
+from httpie.plugins import FormatterPlugin
+
+DEFAULT_INDENT = 4
+
+
+class XMLFormatter(FormatterPlugin):
+
+    def format_body(self, body, mime):
+        if 'xml' in mime:
+            try:
+                parsed_body = xml.dom.minidom.parseString(body)
+            except ExpatError:
+                pass  # Invalid XML, ignore
+            else:
+                return parsed_body.toprettyxml(indent=' ' * DEFAULT_INDENT,
+                                               encoding='UTF-8')

--- a/httpie/plugins/__init__.py
+++ b/httpie/plugins/__init__.py
@@ -11,6 +11,7 @@ from httpie.plugins.manager import PluginManager
 from httpie.plugins.builtin import BasicAuthPlugin, DigestAuthPlugin
 from httpie.output.formatters.headers import HeadersFormatter
 from httpie.output.formatters.json import JSONFormatter
+from httpie.output.formatters.xml import XMLFormatter
 from httpie.output.formatters.colors import ColorFormatter
 
 
@@ -19,4 +20,5 @@ plugin_manager.register(BasicAuthPlugin,
                         DigestAuthPlugin)
 plugin_manager.register(HeadersFormatter,
                         JSONFormatter,
+                        XMLFormatter,
                         ColorFormatter)


### PR DESCRIPTION
Adding very minimalistic but complete XMLFormatter to pretty print `XML` responses.
**Before**
```bash
<note><to>Tove</to><from>Jani</from><heading>Reminder</heading><body>Don't forget me this weekend!</body></note>
```
**After**
```XML
<?xml version="1.0" encoding="UTF-8"?>
<note>
    <to>Tove</to>
    <from>Jani</from>
    <heading>Reminder</heading>
    <body>Don't forget me this weekend!</body>
</note>
```