### PR TITLE
Added test coverage measurement to tox

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -1,0 +1,15 @@
+[run]
+branch = True
+source =
+    httpie
+omit = httpie/tests/*
+
+[report]
+exclude_lines =
+    pragma: no cover
+    except ImportError:
+    def __repr__
+    def __str__
+    raise NotImplementedError
+    def __getattr__
+    raise ValueError

--- a/tox.ini
+++ b/tox.ini
@@ -9,15 +9,18 @@ envlist = py27, py37, pypy
 
 [testenv]
 deps =
+    coverage
     mock
     pytest
     pytest-httpbin>=0.0.6
+    pytest-cov
 
 
 commands =
     # NOTE: the order of the directories in posargs seems to matter.
     # When changed, then many ImportMismatchError exceptions occurrs.
     py.test \
+        --cov=httpie \
         --verbose \
         --doctest-modules \
         {posargs:./httpie ./tests}


### PR DESCRIPTION
Hello there, 

I was curious about the project's test coverage and found out that currently there are no way to measure coverage easily. I did some editing in tox config and now it works perfectly. I thought maybe some other people might be happy if they could measure coverage easily. So I submitted this PR, and hope that you will find it useful and merge it.

Best,
Gábor