### PR TITLE
Updating the hello world usage url

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -179,7 +179,7 @@ Hello World:
 
 .. code-block:: bash
 
-    $ http httpie.org
+    $ http PUT httpbin.org/put hello=world
 
 
 Synopsis:


### PR DESCRIPTION
http httpie.org no longer returns hello world. 

http httpie.org
HTTP/1.1 301 Moved Permanently
CF-RAY: 4c4fa826ba93a39e-MGM
Cache-Control: max-age=3600
Connection: keep-alive
Date: Tue, 09 Apr 2019 21:43:29 GMT
Expires: Tue, 09 Apr 2019 22:43:29 GMT
Location: https://httpie.org/
Server: cloudflare
Transfer-Encoding: chunked
Vary: Accept-Encoding