### PR TITLE
Allow stdin to be a closed fd

### DIFF
--- a/httpie/context.py
+++ b/httpie/context.py
@@ -23,7 +23,7 @@ class Environment(object):
     is_windows = is_windows
     config_dir = DEFAULT_CONFIG_DIR
     stdin = sys.stdin
-    stdin_isatty = stdin.isatty()
+    stdin_isatty = stdin.isatty() if stdin else False
     stdin_encoding = None
     stdout = sys.stdout
     stdout_isatty = stdout.isatty()
@@ -61,7 +61,7 @@ class Environment(object):
         self.__dict__.update(**kwargs)
 
         # Keyword arguments > stream.encoding > default utf8
-        if self.stdin_encoding is None:
+        if self.stdin and self.stdin_encoding is None:
             self.stdin_encoding = getattr(
                 self.stdin, 'encoding', None) or 'utf8'
         if self.stdout_encoding is None:

--- a/httpie/input.py
+++ b/httpie/input.py
@@ -142,6 +142,12 @@ class HTTPieArgumentParser(ArgumentParser):
         if self.args.debug:
             self.args.traceback = True
 
+        self.has_stdin_data = (
+            self.env.stdin
+            and not self.args.ignore_stdin
+            and not self.env.stdin_isatty
+        )
+
         # Arguments processing and environment setup.
         self._apply_no_options(no_options)
         self._validate_download_options()
@@ -150,7 +156,8 @@ class HTTPieArgumentParser(ArgumentParser):
         self._process_pretty_options()
         self._guess_method()
         self._parse_items()
-        if not self.args.ignore_stdin and not env.stdin_isatty:
+
+        if self.has_stdin_data:
             self._body_from_file(self.env.stdin)
         if not URL_SCHEME_RE.match(self.args.url):
             scheme = self.args.default_scheme + "://"
@@ -315,7 +322,7 @@ class HTTPieArgumentParser(ArgumentParser):
         if self.args.method is None:
             # Invoked as `http URL'.
             assert not self.args.items
-            if not self.args.ignore_stdin and not self.env.stdin_isatty:
+            if self.has_stdin_data:
                 self.args.method = HTTP_POST
             else:
                 self.args.method = HTTP_GET
@@ -339,7 +346,7 @@ class HTTPieArgumentParser(ArgumentParser):
                 self.args.url = self.args.method
                 # Infer the method
                 has_data = (
-                    (not self.args.ignore_stdin and not self.env.stdin_isatty)
+                    self.has_stdin_data
                     or any(
                         item.sep in SEP_GROUP_DATA_ITEMS
                         for item in self.args.items


### PR DESCRIPTION
Before this change, the following invocation would not work

```
$ http http://neverhttps.com <&-
```

The "<&-" at the end closes the stdin fd. Specifically, it would fail with

```
  ...
  File "/home/mgsloan/.local/lib/python3.6/site-packages/httpie/context.py", line 26, in Environment
    stdin_isatty = stdin.isatty()
AttributeError: 'NoneType' object has no attribute 'isatty'
```

This can occur when httpie is being programmatically invoked, and may
as well be supported.