### PR TITLE
Fix wrong character output when encoding is not correct

### DIFF
--- a/httpie/models.py
+++ b/httpie/models.py
@@ -42,6 +42,10 @@ class HTTPMessage(object):
 class HTTPResponse(HTTPMessage):
     """A :class:`requests.models.Response` wrapper."""
 
+    def __init__(self, orig):
+        super(HTTPResponse, self).__init__(orig)
+        self._encoding = self._orig.apparent_encoding
+
     def iter_body(self, chunk_size=1):
         return self._orig.iter_content(chunk_size=chunk_size)
 
@@ -80,7 +84,7 @@ class HTTPResponse(HTTPMessage):
 
     @property
     def encoding(self):
-        return self._orig.encoding or 'utf8'
+        return self._encoding or 'utf8'
 
     @property
     def body(self):


### PR DESCRIPTION
Many times web server returns Content-Type without charset info, the encoding returned by
requests will be "ISO-8859-1", however in such situations, it's better to use apparent_encoding instead.

Before:
<img width="669" alt="屏幕快照 2019-08-16 下午3 57 50" src="https://user-images.githubusercontent.com/261698/63152714-10de7d80-c03f-11e9-998f-29624973c560.png">

After:
<img width="761" alt="屏幕快照 2019-08-16 下午3 59 18" src="https://user-images.githubusercontent.com/261698/63152724-16d45e80-c03f-11e9-8bd8-a2f9f7c74110.png">
