### PR TITLE
Add installation instructions for openSUSE

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -103,6 +103,11 @@ system package manager, for example:
     # Arch Linux
     $ pacman -S httpie
 
+.. code-block:: bash
+
+    # openSUSE
+    $ zypper install python3-httpie
+
 
 Windows, etc.
 -------------


### PR DESCRIPTION
HTTPie is available in the official repositories of Leap 15.1 and Tumbleweed.

See: [openSUSE Software](https://software.opensuse.org/package/python3-httpie)