### PR TITLE
Fix make target in CONTRIBUTING.rst

### DIFF
--- a/CONTRIBUTING.rst
+++ b/CONTRIBUTING.rst
@@ -47,7 +47,7 @@ Go to https://github.com/jakubroztocil/httpie and fork the project repository.
 
     # Install dev. requirements and also HTTPie (in editable mode
     # so that the `http' command will point to your working copy):
-    make init
+    make install
 
 
 Making Changes


### PR DESCRIPTION
The first hurdle to contributing was that the instructions does not seem up to date. The command `make init` gives:

    make: *** No rule to make target `init'.  Stop. 

Whereas `make install` does what the comment says `make init` was supposed to do (Install dev. requirements and HTTPie in editable mode)