### PR TITLE
exclude site-packages from .rst file scanning

### DIFF
--- a/tests/test_docs.py
+++ b/tests/test_docs.py
@@ -19,7 +19,7 @@ def has_docutils():
 def rst_filenames():
     # noinspection PyShadowingNames
     for root, dirnames, filenames in os.walk(os.path.dirname(TESTS_ROOT)):
-        if '.tox' not in root:
+        if '.tox' not in root and 'site-packages' not in root:
             for filename in fnmatch.filter(filenames, '*.rst'):
                 yield os.path.join(root, filename)
 


### PR DESCRIPTION
make test fails when finding .rst files from site packages installed
in the virtual environment

For example
C:\\Users\\ceetu\\dev\\httpie\\venv\\Lib\\site-packages\\bleach\\_vendor\\html5lib-1.0.1.dist-info\\DESCRIPTION.rst
