### PR TITLE
run rst2pseudoxml.py with shell=true

### DIFF
--- a/tests/test_docs.py
+++ b/tests/test_docs.py
@@ -34,7 +34,8 @@ def test_rst_file_syntax(filename):
     p = subprocess.Popen(
         ['rst2pseudoxml.py', '--report=1', '--exit-status=1', filename],
         stderr=subprocess.PIPE,
-        stdout=subprocess.PIPE
+        stdout=subprocess.PIPE,
+        shell=True
     )
     err = p.communicate()[1]
     assert p.returncode == 0, err.decode('utf8')


### PR DESCRIPTION
makes rst2pseudoxml.py work properly on Windows

executes via a shell instead of not working

also requires that the py extension is associated with the python interpreter