### PR TITLE
Fix spelling of “GitHub”

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -128,7 +128,7 @@ This project adheres to `Semantic Versioning <https://semver.org/>`_.
   ``$ alias https='http --default-scheme=https``.
 * Added ``-I`` as a shortcut for ``--ignore-stdin``.
 * Added fish shell completion (located in ``extras/httpie-completion.fish``
-  in the Github repo).
+  in the GitHub repo).
 * Updated ``requests`` to 2.10.0 so that SOCKS support can be added via
   ``pip install requests[socks]``.
 * Changed the default JSON ``Accept`` header from ``application/json``

--- a/CONTRIBUTING.rst
+++ b/CONTRIBUTING.rst
@@ -115,7 +115,7 @@ Testing & CI
 Please add tests for any new features and bug fixes.
 
 When you open a pull request,
-`Github Actions <https://github.com/jakubroztocil/httpie/actions>`_
+`GitHub Actions <https://github.com/jakubroztocil/httpie/actions>`_
 will automatically run HTTPie’s `test suite`_ against your code
 so please make sure all checks pass.
 

--- a/README.rst
+++ b/README.rst
@@ -228,7 +228,7 @@ Build and print a request without sending it using `offline mode`_:
     $ http --offline httpbin.org/post hello=offline
 
 
-Use `Github API`_ to post a comment on an
+Use `GitHub API`_ to post a comment on an
 `issue <https://github.com/jakubroztocil/httpie/issues/83>`_
 with `authentication`_:
 
@@ -1933,7 +1933,7 @@ have contributed.
 
 
 .. _pip: https://pip.pypa.io/en/stable/installing/
-.. _Github API: https://developer.github.com/v3/issues/comments/#create-a-comment
+.. _GitHub API: https://developer.github.com/v3/issues/comments/#create-a-comment
 .. _these fine people: https://github.com/jakubroztocil/httpie/contributors
 .. _Jakub Roztocil: https://roztocil.co
 .. _@jakubroztocil: https://twitter.com/jakubroztocil


### PR DESCRIPTION
“Github” → “GitHub”