### PR TITLE
Update tox conf

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -4,7 +4,15 @@
 
 [tox]
 # pypy3 currently fails because of a Flask issue
-envlist = py37
+envlist =
+    codestyle
+    security
+    py36
+    py37
+    py38
+    py39
+
+skip_missing_interpreters = true
 
 
 [testenv]
@@ -15,9 +23,20 @@ deps =
 
 
 commands =
-    # NOTE: the order of the directories in posargs seems to matter.
-    # When changed, then many ImportMismatchError exceptions occurrs.
-    py.test \
-        --verbose \
-        --doctest-modules \
-        {posargs:./httpie ./tests}
+    py.test --verbose --doctest-modules {posargs}
+
+
+[testenv:codestyle]
+deps = pycodestyle
+
+commands = pycodestyle
+
+
+[testenv:security]
+deps =
+    bandit
+    safety
+
+commands =
+    bandit -ll -r httpie
+    safety check


### PR DESCRIPTION
This pull request updates the list of tested Python versions on the tox configuration file **and** adds two new environments.

Previously, the tox configuration only listed Python 3.7 as a target version for tests. With these changes the tox configuration now lists Python 3.6, 3.7, 3.8, and 3.9. Tox will only create environments for the interpreters available.

The two new environments are "codestyle" and "security".
The code style environment will install and run pycodestyle tool, a.k.a. pep8.
The new security related environment will run two tools to check for potential security issues:
1. "[Bandit](https://bandit.readthedocs.io/en/latest/) is a tool designed to find common security issues in Python code."
2. "[Safety](https://github.com/pyupio/safety) checks your installed dependencies for known security vulnerabilities."
