### PR TITLE
Support (part of) the XDG Base Directory Specification

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -1691,8 +1691,11 @@ but you can create it manually.
 Config file directory
 ---------------------
 
-The default location of the configuration file is ``~/.httpie/config.json``
-(or ``%APPDATA%\httpie\config.json`` on Windows).
+The default location of the configuration file on most platforms is
+``$XDG_CONFIG_HOME/httpie/config.json`` (defaulting to
+``~/.config/httpie/config.json``). For backwards compatibility, if the directory
+``~/.httpie`` exists, the configuration file there will be used instead. On
+Windows, the config file is located at ``%APPDATA%\httpie\config.json``.
 
 The config directory can be changed by setting the ``$HTTPIE_CONFIG_DIR``
 environment variable:


### PR DESCRIPTION
On Unix-like systems, the configuration file now lives in `$XDG_CONFIG_HOME/httpie/` by default, not `~/.httpie/` (the behaviour on Windows is unchanged). The previous location is still checked, in order to support existing installations.

Searching `$XDG_CONFIG_DIRS` is still not supported.

Fixes #145; supersedes #436.