### PR TITLE
Added support for connection errors

### DIFF
--- a/httpie/cli/errors.py
+++ b/httpie/cli/errors.py
@@ -1,6 +1,8 @@
 class Error(Exception):
     '''Base Class for custom exceptions'''
-    pass
+    def __init__(self, *args, **kwargs):
+        super().__init__(self,*args, **kwargs)
+    #TODO: Do I need to define custom methods/attributes for Error class or is *args, **kwargs,and built-in methods from Exception class sufficient?
 
 class ConnectionError(Error):
     #TODO: Work on this class together

--- a/httpie/cli/errors.py
+++ b/httpie/cli/errors.py
@@ -1,0 +1,24 @@
+class Error(Exception):
+    '''Base Class for custom exceptions'''
+    pass
+
+class ConnectionError(Error):
+    #TODO: Work on this class together
+    '''Exception raised for error when connecting to server'''
+    pass
+
+class BasicAuthError(Error):
+    '''Exception raised for wrong username and pw when authenticating'''
+    #TODO: may need to account for different auth types within this class
+    pass
+
+class MethodMismatchError(Error):
+    '''Exception raised when the wrong method is used with the wrong URL request'''
+    pass
+
+class LocalHostError(Error):
+    '''Exception raised when the user fails to provide a valid localhost'''
+    pass
+
+#TODO: ADD the rest of the classes including a general catch-all one for errors we may miss
+#TODO: Write tests for intended class functionctionality

--- a/httpie/cli/errors.py
+++ b/httpie/cli/errors.py
@@ -5,9 +5,13 @@ class Error(Exception):
     #TODO: Do I need to define custom methods/attributes for Error class or is *args, **kwargs,and built-in methods from Exception class sufficient?
 
 class ConnectionError(Error):
-    #TODO: Work on this class together
-    '''Exception raised for error when connecting to server'''
-    pass
+    def __init__(self,*args):
+        self.exc = None
+        self.message = None
+
+    def __str__(self):
+        self.message = "Failed to establish a new connection"
+        return self.message
 
 class BasicAuthError(Error):
     '''Exception raised for wrong username and pw when authenticating'''
@@ -20,14 +24,6 @@ class MethodMismatchError(Error):
 
 class LocalHostError(Error):
     '''Exception raised when the user fails to provide a valid localhost'''
-    pass
-
-class InvalidArgument(Error):
-    '''Exception raised when user passes in invalid argument to a parameter'''
-    pass
-
-class OfflineError(Error):
-    '''Exception raised when user attempts a request offline'''
     pass
 
 #TODO: ADD the rest of the classes including a general catch-all one for errors we may miss

--- a/httpie/status.py
+++ b/httpie/status.py
@@ -15,6 +15,7 @@ class ExitStatus(IntEnum):
 
     ERROR_TOO_MANY_REDIRECTS = 6
     PLUGIN_ERROR = 7
+    CONNECTION_ERROR = 8
     # 128+2 SIGINT
     # <http://www.tldp.org/LDP/abs/html/exitcodes.html>
     ERROR_CTRL_C = 130

--- a/tests/test_errors.py
+++ b/tests/test_errors.py
@@ -2,7 +2,6 @@ import mock
 from pytest import raises
 from requests import Request
 from requests.exceptions import ConnectionError
-
 from httpie.status import ExitStatus
 from utils import HTTP_OK, http
 

--- a/tests/test_exceptions.py
+++ b/tests/test_exceptions.py
@@ -1,0 +1,7 @@
+'''Test suite for custom exception classes'''
+import mock
+from pytest import raises
+from requests import Request
+from requests.exceptions import ConnectionError
+from httpie.status import ExitStatus
+from utils import HTTP_OK, http


### PR DESCRIPTION
Instead of verbose output when httpie cannot establish connection, now prints prettified output of 
`Failed to establish a new connection to url: https:____`
- both --traceback and --debug functionality still supported
- need to add testing