### PR TITLE
Combine cookies from original request and session file

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -1760,7 +1760,6 @@ To set a cookie within a Session there are three options:
 3. Manually set cookie parameters in the json file of the session
 
 .. code-block:: json
-    :emphasize-lines: 12-19
     
     {
         "__meta__": {

--- a/README.rst
+++ b/README.rst
@@ -530,7 +530,6 @@ Simple example:
     $ http PUT httpbin.org/put name=John email=john@example.org
 
 .. code-block:: http
-
     PUT / HTTP/1.1
     Accept: application/json, */*;q=0.5
     Accept-Encoding: gzip, deflate
@@ -1738,6 +1737,61 @@ exchange after it has been created, specify the session name via
 
     # But it is not updated:
     $ http --session-read-only=./ro-session.json httpbin.org/headers Custom-Header:new-value
+
+Cookie Storage Behaviour
+------------------------
+
+**TL;DR:** Cookie storage priority: Server response > Command line request > Session file 
+
+To set a cookie within a Session there are three options: 
+
+1. Get a `Set-Cookie` header in a response from a server
+
+.. code-block:: bash
+
+    $ http --session=./session.json httpbin.org/cookie/set?foo=bar
+
+2. Set the cookie name and value through the command line as seen in `cookies`_
+
+.. code-block:: bash
+
+    $ http --session=./session.json httpbin.org/headers Cookie:foo=bar
+
+3. Manually set cookie parameters in the json file of the session
+
+.. code-block:: json
+    :emphasize-lines: 12-19
+    
+    {
+        "__meta__": {
+        "about": "HTTPie session file",
+        "help": "https://httpie.org/doc#sessions",
+        "httpie": "2.2.0-dev"
+        },
+        "auth": {
+            "password": null,
+            "type": null,
+            "username": null
+        },
+        "cookies": {
+            "foo": {
+                "expires": null,
+                "path": "/",
+                "secure": false,
+                "value": "bar"
+                }
+        }
+    }
+
+Cookies will be set in the session file with the priority specified above. For example, a cookie
+set through the command line will overwrite a cookie of the same name stored 
+in the session file. If the server returns a `Set-Cookie` header with a
+cookie of the same name, the returned cookie will overwrite the preexisting cookie.
+
+Expired cookies are never stored. If a cookie in a session file expires, it will be removed before
+sending a new request. If the server expires an existing cookie, it will also be removed from the
+session file. 
+
 
 Config
 ======

--- a/httpie/sessions.py
+++ b/httpie/sessions.py
@@ -78,6 +78,12 @@ class Session(BaseConfigDict):
             value = value.decode('utf8')
             if name == 'User-Agent' and value.startswith('HTTPie/'):
                 continue
+            
+            if name == 'Cookie':
+                for cookie in value.split(';'):
+                    key, value = cookie.split("=")
+                    self['cookies'][key] = {'value': value}
+                del request_headers['Cookie']
 
             for prefix in SESSION_IGNORED_HEADER_PREFIXES:
                 if name.lower().startswith(prefix.lower()):

--- a/httpie/sessions.py
+++ b/httpie/sessions.py
@@ -81,8 +81,8 @@ class Session(BaseConfigDict):
 
             if name == 'Cookie':
                 for cookie in value.split(';'):
-                    key, value = cookie.split("=")
-                    self['cookies'][key.strip()] = {'value': value.strip()}
+                    name, value = cookie.split("=")
+                    self['cookies'][name.strip()] = {'value': value.strip()}
                 del request_headers['Cookie']
                 continue
 

--- a/httpie/sessions.py
+++ b/httpie/sessions.py
@@ -84,7 +84,7 @@ class Session(BaseConfigDict):
             if name.lower() == 'cookie':
                 for cookie_name, morsel in SimpleCookie(value).items():
                     self['cookies'][cookie_name] = {'value': morsel.value}
-                del request_headers['Cookie']
+                del request_headers[name]
                 continue
 
             for prefix in SESSION_IGNORED_HEADER_PREFIXES:

--- a/httpie/sessions.py
+++ b/httpie/sessions.py
@@ -78,12 +78,13 @@ class Session(BaseConfigDict):
             value = value.decode('utf8')
             if name == 'User-Agent' and value.startswith('HTTPie/'):
                 continue
-            
+
             if name == 'Cookie':
                 for cookie in value.split(';'):
                     key, value = cookie.split("=")
-                    self['cookies'][key] = {'value': value}
+                    self['cookies'][key.strip()] = {'value': value.strip()}
                 del request_headers['Cookie']
+                continue
 
             for prefix in SESSION_IGNORED_HEADER_PREFIXES:
                 if name.lower().startswith(prefix.lower()):

--- a/httpie/sessions.py
+++ b/httpie/sessions.py
@@ -4,6 +4,8 @@ Persistent, JSON-serialized sessions.
 """
 import os
 import re
+
+from http.cookies import SimpleCookie
 from pathlib import Path
 from typing import Iterable, Optional, Union
 from urllib.parse import urlsplit
@@ -79,10 +81,9 @@ class Session(BaseConfigDict):
             if name == 'User-Agent' and value.startswith('HTTPie/'):
                 continue
 
-            if name == 'Cookie':
-                for cookie in value.split(';'):
-                    name, value = cookie.split("=")
-                    self['cookies'][name.strip()] = {'value': value.strip()}
+            if name.lower() == 'cookie':
+                for cookie_name, morsel in SimpleCookie(value).items():
+                    self['cookies'][cookie_name] = {'value': morsel.value}
                 del request_headers['Cookie']
                 continue
 

--- a/httpie/sessions.py
+++ b/httpie/sessions.py
@@ -78,7 +78,7 @@ class Session(BaseConfigDict):
                 continue  # Ignore explicitly unset headers
 
             value = value.decode('utf8')
-            if name == 'User-Agent' and value.startswith('HTTPie/'):
+            if name.lower() == 'user-agent' and value.startswith('HTTPie/'):
                 continue
 
             if name.lower() == 'cookie':

--- a/tests/test_sessions.py
+++ b/tests/test_sessions.py
@@ -1,4 +1,5 @@
 # coding=utf-8
+import json
 import os
 import shutil
 import sys
@@ -186,3 +187,22 @@ class TestSession(SessionTestBase):
                  httpbin.url + '/get', env=self.env())
         finally:
             os.chdir(cwd)
+    
+    def test_existing_and_new_cookies_sent_in_request(self, httpbin):
+        self.start_session(httpbin)
+        orig_session = {
+            'cookies': {
+                'existing': {
+                    'value': 'foo'
+                }
+            }
+        }
+        session_path = self.config_dir / 'test-session.json'
+        session_path.write_text(json.dumps(orig_session))
+
+        r = http(
+            '--session', str(session_path),
+            '--print=H',
+            httpbin.url, 'Cookie:new=bar',
+        )
+        assert 'Cookie: existing=foo; new=bar' in r

--- a/tests/test_sessions.py
+++ b/tests/test_sessions.py
@@ -189,16 +189,25 @@ class TestSession(SessionTestBase):
             os.chdir(cwd)
 
     @pytest.mark.parametrize(
-        "new_cookies, expected, expected_dict",
-        [("new=bar", "existing_cookie=foo; new=bar", {"new": "bar"}),
-        ("new=bar;chocolate=milk", "chocolate=milk; existing_cookie=foo; new=bar",\
-         {"new": "bar", "chocolate": "milk"}),
-        ("new=bar; chocolate=milk", "chocolate=milk; existing_cookie=foo; new=bar",\
-         {"new": "bar", "chocolate": "milk"})]
+        argnames=["new_cookies", "new_cookies_dict", "expected"],
+        argvalues=[(
+            "new=bar",
+            {"new": "bar"},
+            "existing_cookie=foo; new=bar"
+        ),
+            (
+            "new=bar;chocolate=milk",
+            {"new": "bar", "chocolate": "milk"},
+            "chocolate=milk; existing_cookie=foo; new=bar"
+        ),
+            (
+            "new=bar; chocolate=milk",
+            {"new": "bar", "chocolate": "milk"},
+            "chocolate=milk; existing_cookie=foo; new=bar"
+        )
+        ]
     )
-    def test_existing_and_new_cookies_sent_in_request(self, new_cookies,\
-                                                      expected, expected_dict,\
-                                                      httpbin):
+    def test_existing_and_new_cookies_sent_in_request(self, new_cookies, new_cookies_dict, expected, httpbin):
         self.start_session(httpbin)
         orig_session = {
             'cookies': {
@@ -213,20 +222,13 @@ class TestSession(SessionTestBase):
         r = http(
             '--session', str(session_path),
             '--print=H',
-            httpbin.url, 'Cookie:'+ new_cookies,
+            httpbin.url,
+            'Cookie:' + new_cookies,
         )
-        #Note: cookies in response are in alphabetical order
+        # Note: cookies in response are in alphabetical order
         assert 'Cookie: ' + expected in r
-        updated_session = json.loads(session_path.read_text())
 
-        # TODO: REMOVE print(updated_session)
-        for name, value in expected_dict.items():
+        updated_session = json.loads(session_path.read_text())
+        for name, value in new_cookies_dict.items():
             assert name, value in updated_session['cookies']
             assert "Cookie" not in updated_session['headers']
-
-
-
-
-
-
-

--- a/tests/test_sessions.py
+++ b/tests/test_sessions.py
@@ -187,13 +187,18 @@ class TestSession(SessionTestBase):
                  httpbin.url + '/get', env=self.env())
         finally:
             os.chdir(cwd)
-    
+
     @pytest.mark.parametrize(
-        "new_cookies, expected", 
-        [("new=bar", "existing_cookie=foo; new=bar"),
-        ("new=bar; chocolate=milk", "chocolate=milk; existing_cookie=foo; new=bar")]
+        "new_cookies, expected, expected_dict",
+        [("new=bar", "existing_cookie=foo; new=bar", {"new": "bar"}),
+        ("new=bar;chocolate=milk", "chocolate=milk; existing_cookie=foo; new=bar",\
+         {"new": "bar", "chocolate": "milk"}),
+        ("new=bar; chocolate=milk", "chocolate=milk; existing_cookie=foo; new=bar",\
+         {"new": "bar", "chocolate": "milk"})]
     )
-    def test_existing_and_new_cookies_sent_in_request(self, new_cookies, expected, httpbin):
+    def test_existing_and_new_cookies_sent_in_request(self, new_cookies,\
+                                                      expected, expected_dict,\
+                                                      httpbin):
         self.start_session(httpbin)
         orig_session = {
             'cookies': {
@@ -212,3 +217,16 @@ class TestSession(SessionTestBase):
         )
         #Note: cookies in response are in alphabetical order
         assert 'Cookie: ' + expected in r
+        updated_session = json.loads(session_path.read_text())
+
+        # TODO: REMOVE print(updated_session)
+        for name, value in expected_dict.items():
+            assert name, value in updated_session['cookies']
+            assert "Cookie" not in updated_session['headers']
+
+
+
+
+
+
+

--- a/tests/test_sessions.py
+++ b/tests/test_sessions.py
@@ -295,6 +295,16 @@ class TestExpiredCookies:
         "new=bar; chocolate=milk",
         {"new": "bar", "chocolate": "milk"},
         "chocolate=milk; existing_cookie=foo; new=bar"
+    ),
+        (
+        "new=bar;; chocolate=milk;;;",
+        {"new": "bar", "chocolate": "milk"},
+        "existing_cookie=foo; new=bar"
+    ),
+        (
+        "new=bar; chocolate=milk;;;",
+        {"new": "bar", "chocolate": "milk"},
+        "chocolate=milk; existing_cookie=foo; new=bar"
     )
     ]
 )


### PR DESCRIPTION
This pull request should address #824. Cookies that are set through a request in the CLI are added to the session cookies. @gmelodie