### PR TITLE
Add test to test auth plugin reused in session

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -878,7 +878,7 @@ The currently supported authentication schemes are Basic and Digest
                         have higher priority).
 
 ``--auth-type, -A``     Specify the auth mechanism. Possible values are
-                        ``basic`` and ``digest``. The default value is
+                        ``basic``, ``digest``, or the name of any `auth plugins`_ you have installed. The default value is
                         ``basic`` so it can often be omitted.
 ===================     ======================================================
 

--- a/tests/test_sessions.py
+++ b/tests/test_sessions.py
@@ -223,8 +223,6 @@ class TestSession(SessionTestBase):
 
             def get_auth(self, username=None, password=None):
                 assert self.raw_auth == 'user:password'
-                assert username == 'user'
-                assert password == 'password'
                 return basic_auth(header='Custom dXNlcjpwYXNzd29yZA==')
 
         plugin_manager.register(Plugin)
@@ -256,9 +254,6 @@ class TestSession(SessionTestBase):
             auth_require = True
 
             def get_auth(self, username=None, password=None):
-                assert self.raw_auth == 'user:password'
-                assert username == 'user'
-                assert password == 'password'
                 return basic_auth()
 
         plugin_manager.register(Plugin)

--- a/tests/test_sessions.py
+++ b/tests/test_sessions.py
@@ -235,7 +235,7 @@ class TestSession(SessionTestBase):
             auth_parse = auth_parse_param
 
             def get_auth(self, username=None, password=None):
-                return basic_auth(header='{}=='.format(header))
+                return basic_auth(header=f'{header}==')
 
         plugin_manager.register(Plugin)
 
@@ -253,8 +253,8 @@ class TestSession(SessionTestBase):
             httpbin + '/basic-auth/user/password',
             '--print=H',
         )
-        assert "Authorization: {}".format(header) in r1
-        assert "Authorization: {}".format(header) in r2
+        assert f'Authorization: {header}' in r1
+        assert f'Authorization: {header}' in r2
         plugin_manager.unregister(Plugin)
 
     @mock.patch('httpie.cli.argtypes.AuthCredentials._getpass',
@@ -276,7 +276,7 @@ class TestSession(SessionTestBase):
             httpbin + '/basic-auth/user/password',
             '--auth-type',
             Plugin.auth_type,
-            '--auth', 'user',
+            '--auth', 'user:',
         )
 
         r2 = http(


### PR DESCRIPTION
Hoping to resolve #937 with this PR. 

Looking for feedback to verify that the first test (`test_auth_type_reused_in_session`) is a valid test as it is currently failing. 